### PR TITLE
Card webhook

### DIFF
--- a/assets/ios/shareExtension/Config.swift
+++ b/assets/ios/shareExtension/Config.swift
@@ -10,10 +10,10 @@ import Foundation
 
 enum Config {
     // dev
-    static let webhookURL = URL(string: "http://localhost:3000/custom/links")!
+    static let webhookURL = URL(string: "http://localhost:3000/shares")!
     static let apiKey = "KAhbB18D0QZBFXBCJKE4xJZYyaWkUTK25LWrqNMIXI2-FSqT5NgJpA-ermcllZG3s8mqioWkfZWNlUVwcOIGrw"
 
     // production
-//    static let webhookURL = URL(string: "https://ciw-list.herokuapp.com/custom/links")!
+//    static let webhookURL = URL(string: "https://ciw-list.herokuapp.com/shares")!
 //    static let apiKey = "fake_api_key"
 }

--- a/src/screens/BoardEdit/EditBoardForm.js
+++ b/src/screens/BoardEdit/EditBoardForm.js
@@ -80,6 +80,14 @@ export default function EditBoardForm({board, onSave, onDelete, onCancel}) {
         style={sharedStyles.mt}
       />
       <TextField
+        label="Card Create Webhook"
+        value={attributes.options.webhooks?.['card-create'] ?? ''}
+        onChangeText={value =>
+          updateAttribute('options.webhooks["card-create"]', value || null)
+        }
+        style={sharedStyles.mt}
+      />
+      <TextField
         label="Card Update Webhook"
         value={attributes.options.webhooks?.['card-update'] ?? ''}
         onChangeText={value =>


### PR DESCRIPTION
- Adds a field to configure a card-create webhook for a board
- Updates the URL the share extension uses from the hard-coded one to the more general `/shares`